### PR TITLE
Add pydeface as a defacing option

### DIFF
--- a/3_datasharing.html
+++ b/3_datasharing.html
@@ -493,6 +493,7 @@
 </li>
 <li><p>Some datasets may be identifiable even if they do not contain any of the 18 identifiers. For example, a dataset that contains only families with 4 or more children within a particular age range from a particular state could allow those individuals to be re-identified. In this case, one would need additional protections for data sharing.</p>
 </li>
+<li><p>To remove the facial features present in a brain image, one may consider using <a href="https://github.com/poldracklab/pydeface" target="_blank">pydeface</a>< 
 </ul>
 <h3 id="how-can-i-maximize-the-impact-of-my-shared-dataset">How can I maximize the impact of my shared dataset?</h3>
 <ul>


### PR DESCRIPTION
In the FAQ section of `data sharing` under the [deidentification question](https://poldrack.github.io/psych-open-science-guide/3_datasharing.html#what-does-deidentification-mean-and-how-can-i-do-it), I propose to add pydeface as a method for removing facial features from a brain image